### PR TITLE
Set ckan.auth.create_user_via_web to false

### DIFF
--- a/ckan.ini
+++ b/ckan.ini
@@ -73,7 +73,7 @@ ckan.auth.user_create_organizations = false
 ckan.auth.user_delete_groups = true
 ckan.auth.user_delete_organizations = true
 ckan.auth.create_user_via_api = false
-ckan.auth.create_user_via_web = true
+ckan.auth.create_user_via_web = false
 ckan.auth.roles_that_cascade_to_sub_groups = admin
 
 


### PR DESCRIPTION
This is to prevent new spam users from registering. We have four hundred thousand odd spam registrations.